### PR TITLE
Add `Writer.transfer'`

### DIFF
--- a/lib/writer.mli
+++ b/lib/writer.mli
@@ -330,8 +330,12 @@ val save_sexp
 
     [transfer] causes [Pipe.flushed] on [pipe_r]'s writer to ensure that the bytes have
     been flushed to [t] before returning.  It also waits on [Pipe.upstream_flushed] at
-    shutdown. *)
+    shutdown.
+
+    [transfer'] works similar to [transfer] but allows to perform async actions in [f].
+    *)
 val transfer : t -> 'a Pipe.Reader.t -> ('a -> unit) -> unit Deferred.t
+val transfer' : t -> 'a Pipe.Reader.t -> ('a Queue.t -> unit Deferred.t) -> unit Deferred.t
 
 (** [pipe t] returns the writing end of a pipe attached to [t] that pushes back when [t]
     cannot keep up with the data being pushed in.  Closing the pipe will close [t]. *)


### PR DESCRIPTION
Note I tested this on top of 109.34.00, then rebased to master but didn't compile since I don't have git versions of dependencies installed (which seem to be required).

`Writer.transfer'` is similar to `Writer.transfer`, but allowing to use async actions inside the given callback.

See https://groups.google.com/forum/#!topic/ocaml-core/nFpAMKoWRYo for a related discussion.

Here's a demonstration:

``` ocaml
open Core.Std
open Async.Std

let main () =
    let r = Pipe.of_list ["Foo"; "Bar"; "Baz"] in

    Writer.with_file
        ?perm:(Some 0o600)
        ?append:(Some false)
        ?exclusive:(Some true)
        "data.dat"
        ~f:(fun w ->
            Writer.transfer' w r (
                let rec loop q = match Queue.dequeue q with
                  | None -> return ()
                  | Some s ->
                      Writer.write_line w s;
                      Writer.flushed w >>= fun () ->
                      Writer.fdatasync w >>= fun () ->
                      loop q
                in
                loop))
    >>| fun () ->
    Shutdown.shutdown 0
;;

let _ = main () in
never_returns (Scheduler.go ())
```

```
$ strace -ff -e writev,fdatasync ./file.native 
Process 902 attached
Process 903 attached
Process 904 attached
Process 905 attached
[pid   905] writev(5, [{"Foo\n", 4}], 1) = 4
[pid   902] fdatasync(5)                = 0
[pid   905] writev(5, [{"Bar\n", 4}], 1) = 4
[pid   902] fdatasync(5)                = 0
[pid   905] writev(5, [{"Baz\n", 4}], 1) = 4
[pid   902] fdatasync(5)                = 0
[pid   903] --- SIGRTMIN {si_signo=SIGRTMIN, si_code=SI_TKILL, si_pid=901, si_uid=1000} ---
[pid   903] <... futex resumed> )       = ? <unavailable>
[pid   905] +++ exited with 0 +++
[pid   904] +++ exited with 0 +++
[pid   903] +++ exited with 0 +++
[pid   902] +++ exited with 0 +++
+++ exited with 0 +++
$ cat data.dat 
Foo
Bar
Baz
```

Note this demonstration is _not safe_ against power loss (even though `fdatasync` is used).
