### PR TITLE
Document semantics of fsync and fdatasync

### DIFF
--- a/src/writer.mli
+++ b/src/writer.mli
@@ -414,7 +414,11 @@ val flushed : t -> unit Deferred.t
 
 val flushed_time : t -> Time.t Deferred.t
 val flushed_time_ns : t -> Time_ns.t Deferred.t
+
+(** [fsync t] calls [flushed t] before calling [Unix.fsync] on the underlying file descriptor *)
 val fsync : t -> unit Deferred.t
+
+(** [fdatasync t] calls [flushed t] before calling [Unix.fdatasync] on the underlying file descriptor *)
 val fdatasync : t -> unit Deferred.t
 
 (** [send] writes a string to the writer that can be read back using [Reader.recv]. *)


### PR DESCRIPTION
With the current documentation it is unclear whether `fsync t` just calls fsync on the underlying file descriptor, or waits until all previous writes have occurred before calling fsync.

This PR hopefully clears that up.

I'm not 100% clear on the syntax for odoc so it is possible I haven't done it quite right.